### PR TITLE
Feature/gh pages jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.sass-cache/
+.jekyll-metadata
+*.swp

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/docs/_data/members.yml
+++ b/docs/_data/members.yml
@@ -1,0 +1,17 @@
+- name: Daniil159x
+  solved_num: 51
+
+- name: atrest890
+  solved_num: 31
+
+- name: Sever_wolf
+  solved_num: 26
+
+- name: Nirowe_Cesey
+  solved_num: 18
+
+- name: c0nst_float
+  solved_num: 18
+
+- name: alexandrdum
+  solved_num: 12

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <div class="container">
+      <section id="main_content">
+        {{ content }}
+      </section>
+    </div>
+
+  </body>
+</html>
+

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,6 @@
+## Our credentials
+
+- E-mail: [team@neos.fun](mailto:team@neos.fun)
+- Twitter: [NeosFun](https://twitter.com/NeosFun)
+- CTFTime: [57870](https://ctftime.org/team/57870)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+---
+title: Neo's Fun - legal hackers team
+---
+
+# `Neo's Fun` - legal hackers team
+
+{% include_relative rating.md members=site.data.members %}
+
+{% include_relative upcoming.md %}
+
+{% include_relative links.md %}
+
+{% include_relative credentials.md %}
+

--- a/docs/links.md
+++ b/docs/links.md
@@ -1,0 +1,8 @@
+## Useful links
+
+- [KMB](http://kmb.ufoctf.ru)
+- [Hackerdom training](http://training.hackerdom.ru)
+- [Cryptool](https://www.cryptool.org/en)
+- [Good articles about networks](http://linkmeup.ru/blog/11.html)
+- [ITSecWiki](http://itsecwiki.org)
+

--- a/docs/rating.md
+++ b/docs/rating.md
@@ -1,0 +1,6 @@
+## Current rating
+
+{% assign sorted = include.members %}
+{% for member in sorted %}
+- `{{ member.name }}` - {{ member.solved_num }} Quests Solved
+{% endfor %}

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -1,0 +1,4 @@
+## Upcoming events
+
+- `PlaidCTF` (5 March 2018): [CTFTime](https://ctftime.org/event/617)
+


### PR DESCRIPTION
Перевел существующий сайт на Jekyll (специально для GitHub Pages).
Теперь можно фигачить neos.fun в маркдауне.
Все, что касается именно САЙТА лежит в docs.
Инфа об участниках лежит в docs/_data_members.yml.
После влития в мастер необходимо будет в настройках указать использование директории docs.
Ну и после влития вебхук станет бесполезен, ибо в репе лежат не html-файлы. Поэтому вливать надо при отказе от своего сервака для сайта.